### PR TITLE
fix typo in MyProgramInstruction

### DIFF
--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -1,4 +1,4 @@
-use crate::instruction::{self, MyProgramInstrution};
+use crate::instruction::{self, MyProgramInstruction};
 use pinocchio::{
     account_info::AccountInfo, no_allocator, nostd_panic_handler, program_entrypoint,
     program_error::ProgramError, pubkey::Pubkey, ProgramResult,
@@ -22,12 +22,12 @@ fn process_instruction(
         .split_first()
         .ok_or(ProgramError::InvalidInstructionData)?;
 
-    match MyProgramInstrution::try_from(ix_disc)? {
-        MyProgramInstrution::InitializeState => {
+    match MyProgramInstruction::try_from(ix_disc)? {
+        MyProgramInstruction::InitializeState => {
             log!("Ix:0");
             instruction::process_initilaize_state(accounts, instruction_data)
         }
-        MyProgramInstrution::UpdateState => {
+        MyProgramInstruction::UpdateState => {
             log!("Ix:1");
             instruction::process_update_state(accounts, instruction_data)
         }

--- a/src/instruction/mod.rs
+++ b/src/instruction/mod.rs
@@ -7,18 +7,18 @@ pub use initialize_mystate::*;
 pub use update_mystate::*;
 
 #[repr(u8)]
-pub enum MyProgramInstrution {
+pub enum MyProgramInstruction {
     InitializeState,
     UpdateState,
 }
 
-impl TryFrom<&u8> for MyProgramInstrution {
+impl TryFrom<&u8> for MyProgramInstruction {
     type Error = ProgramError;
 
     fn try_from(value: &u8) -> Result<Self, Self::Error> {
         match *value {
-            0 => Ok(MyProgramInstrution::InitializeState),
-            1 => Ok(MyProgramInstrution::UpdateState),
+            0 => Ok(MyProgramInstruction::InitializeState),
+            1 => Ok(MyProgramInstruction::UpdateState),
             _ => Err(ProgramError::InvalidInstructionData),
         }
     }


### PR DESCRIPTION
Change `MyProgramInstrution` to `MyProgramInstruction`.