### PR TITLE
fix: made all tests pass by separating v1 and v2 instructions into separate handlers

### DIFF
--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -18,6 +18,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "agave-feature-set"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +87,17 @@ dependencies = [
  "solana-sdk-ids",
  "solana-secp256k1-program",
  "solana-secp256r1-program",
+]
+
+[[package]]
+name = "agave-reserved-account-keys"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732a49e540c5b7b8d8943d50ad4b51b98ad9951494053b51fb909c140d3df8b1"
+dependencies = [
+ "agave-feature-set",
+ "solana-pubkey",
+ "solana-sdk-ids",
 ]
 
 [[package]]
@@ -103,6 +150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -547,6 +603,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -658,6 +725,15 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1380,6 +1456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1521,16 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kaigan"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba15de5aeb137f0f65aa3bf82187647f1285abfe5b20c80c2c37f7007ad519a"
+dependencies = [
+ "borsh 0.10.4",
+ "serde",
 ]
 
 [[package]]
@@ -1523,6 +1627,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litesvm"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bca37ac374948b348e29c74b324dc36f18bbbd1ccf80e2046d967521cbd143"
+dependencies = [
+ "agave-feature-set",
+ "agave-precompiles",
+ "agave-reserved-account-keys",
+ "ansi_term",
+ "bincode",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "solana-account",
+ "solana-address-lookup-table-interface",
+ "solana-bpf-loader-program",
+ "solana-builtins",
+ "solana-clock",
+ "solana-compute-budget",
+ "solana-compute-budget-instruction",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee",
+ "solana-fee-structure",
+ "solana-hash",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-keypair",
+ "solana-last-restart-slot",
+ "solana-loader-v3-interface 5.0.0",
+ "solana-loader-v4-interface",
+ "solana-log-collector",
+ "solana-message",
+ "solana-native-token 3.0.0",
+ "solana-nonce",
+ "solana-nonce-account",
+ "solana-precompile-error",
+ "solana-program-error",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sha256-hasher",
+ "solana-signature",
+ "solana-signer",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-stake-interface",
+ "solana-svm-callback",
+ "solana-svm-transaction",
+ "solana-system-interface",
+ "solana-system-program",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "solana-timings",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
+ "solana-vote-program",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1733,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -1987,6 +2166,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2795,6 +2986,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-builtins"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72254e1c55b25fa5a58af23fb7e4740ca757a293c898858b4a48bd2fa8042d84"
+dependencies = [
+ "agave-feature-set",
+ "solana-bpf-loader-program",
+ "solana-compute-budget-program",
+ "solana-hash",
+ "solana-loader-v4-program",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-stake-program",
+ "solana-system-program",
+ "solana-vote-program",
+ "solana-zk-elgamal-proof-program",
+ "solana-zk-token-proof-program",
+]
+
+[[package]]
+name = "solana-builtins-default-costs"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d06100155db23ed947f105aa63d46458faa4a58e971b628c4e786509da6bbcd"
+dependencies = [
+ "agave-feature-set",
+ "ahash",
+ "log",
+ "solana-bpf-loader-program",
+ "solana-compute-budget-program",
+ "solana-loader-v4-program",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-stake-program",
+ "solana-system-program",
+ "solana-vote-program",
+]
+
+[[package]]
 name = "solana-client-traits"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,6 +3091,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-compute-budget-instruction"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be5c9ffd6dd67004bc93dfd2f613ccb01b95fd4e0ad037434558cfa0fe130a7"
+dependencies = [
+ "agave-feature-set",
+ "log",
+ "solana-borsh",
+ "solana-builtins-default-costs",
+ "solana-compute-budget",
+ "solana-compute-budget-interface",
+ "solana-instruction",
+ "solana-packet",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-svm-transaction",
+ "solana-transaction-error",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "solana-compute-budget-interface"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,6 +3122,28 @@ dependencies = [
  "serde_derive",
  "solana-instruction",
  "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-compute-budget-program"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc0130c54e2b2acc3b943d4a1a789fb48c9f72af5c61f5dde393e1e50223013"
+dependencies = [
+ "solana-program-runtime",
+]
+
+[[package]]
+name = "solana-config-program-client"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53aceac36f105fd4922e29b4f0c1f785b69d7b3e7e387e384b8985c8e0c3595e"
+dependencies = [
+ "bincode",
+ "borsh 0.10.4",
+ "kaigan",
+ "serde",
+ "solana-program",
 ]
 
 [[package]]
@@ -3044,6 +3318,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-fee"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71d093270ecbeba22b88e4556c0c02705305c6ed1469d7a31f47f41e7efd827"
+dependencies = [
+ "agave-feature-set",
+ "solana-fee-structure",
+ "solana-svm-transaction",
+]
+
+[[package]]
 name = "solana-fee-calculator"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,7 +3348,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-message",
- "solana-native-token",
+ "solana-native-token 2.3.0",
 ]
 
 [[package]]
@@ -3272,6 +3557,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-loader-v4-program"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa980c021f655b702c4282c10422ea0f7d10ee00347be45ad329d317a0af6f3"
+dependencies = [
+ "log",
+ "qualifier_attr",
+ "solana-account",
+ "solana-bincode",
+ "solana-bpf-loader-program",
+ "solana-instruction",
+ "solana-loader-v3-interface 5.0.0",
+ "solana-loader-v4-interface",
+ "solana-log-collector",
+ "solana-measure",
+ "solana-packet",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-sbpf",
+ "solana-sdk-ids",
+ "solana-transaction-context",
+ "solana-type-overrides",
+]
+
+[[package]]
 name = "solana-log-collector"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,6 +3664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61515b880c36974053dd499c0510066783f0cc6ac17def0c7ef2a244874cf4a9"
 
 [[package]]
+name = "solana-native-token"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
+
+[[package]]
 name = "solana-nonce"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,6 +3730,7 @@ name = "solana-pinocchio-starter"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "litesvm",
  "mollusk-svm",
  "mollusk-svm-bencher",
  "pinocchio",
@@ -3535,7 +3852,7 @@ dependencies = [
  "solana-loader-v4-interface",
  "solana-message",
  "solana-msg",
- "solana-native-token",
+ "solana-native-token 2.3.0",
  "solana-nonce",
  "solana-program-entrypoint",
  "solana-program-error",
@@ -3812,7 +4129,7 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-message",
- "solana-native-token",
+ "solana-native-token 2.3.0",
  "solana-nonce-account",
  "solana-offchain-message",
  "solana-packet",
@@ -3968,9 +4285,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
+checksum = "5aa3feb32c28765f6aa1ce8f3feac30936f16c5c3f7eb73d63a5b8f6f8ecdc44"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall",
@@ -4081,6 +4398,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-stake-program"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ee3fde30acddc028581afdf16de9b89091c2bab7b0b5651b7d473273d9a5d5"
+dependencies = [
+ "agave-feature-set",
+ "bincode",
+ "log",
+ "solana-account",
+ "solana-bincode",
+ "solana-clock",
+ "solana-config-program-client",
+ "solana-genesis-config",
+ "solana-instruction",
+ "solana-log-collector",
+ "solana-native-token 2.3.0",
+ "solana-packet",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-stake-interface",
+ "solana-sysvar",
+ "solana-transaction-context",
+ "solana-type-overrides",
+ "solana-vote-interface",
+]
+
+[[package]]
 name = "solana-svm-callback"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,6 +4442,20 @@ name = "solana-svm-feature-set"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c75d9e63442629ecf438f9fbb5647b92c1d7f66c5eb1d46bcfa4eb34cd457f86"
+
+[[package]]
+name = "solana-svm-transaction"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc3d7bb7e0d630d28295b1a51b240a32922f598b6a72b3b821c7d6c9463702e"
+dependencies = [
+ "solana-hash",
+ "solana-message",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-transaction",
+]
 
 [[package]]
 name = "solana-system-interface"
@@ -4157,9 +4517,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50c92bc019c590f5e42c61939676e18d14809ed00b2a59695dd5c67ae72c097"
+checksum = "b8c3595f95069f3d90f275bb9bd235a1973c4d059028b0a7f81baca2703815db"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4312,6 +4672,145 @@ dependencies = [
  "solana-serialize-utils",
  "solana-short-vec",
  "solana-system-interface",
+]
+
+[[package]]
+name = "solana-vote-program"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a0e62cf9bc0483152abac9338d067a961f2cc3f4bd8b321129d15db499bb64"
+dependencies = [
+ "agave-feature-set",
+ "bincode",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-bincode",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-metrics",
+ "solana-packet",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-signer",
+ "solana-slot-hashes",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-vote-interface",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "solana-zk-elgamal-proof-program"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c857b47345e9017b7906579b5742381de76a9b4785f5d9d3a997a42211825245"
+dependencies = [
+ "agave-feature-set",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-instruction",
+ "solana-log-collector",
+ "solana-program-runtime",
+ "solana-sdk-ids",
+ "solana-zk-sdk",
+]
+
+[[package]]
+name = "solana-zk-sdk"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c13cbe908b9142274d5cdedc57b6bbc705181d05c7a2c7df21a76ad93463119"
+dependencies = [
+ "aes-gcm-siv",
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek 4.1.3",
+ "itertools 0.12.1",
+ "js-sys",
+ "merlin",
+ "num-derive",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha3",
+ "solana-derivation-path",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "subtle",
+ "thiserror 2.0.12",
+ "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-zk-token-proof-program"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441d519b441143d4f8a44d958a160c868e22abc42e007d428264b4392267bc9"
+dependencies = [
+ "agave-feature-set",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-instruction",
+ "solana-log-collector",
+ "solana-program-runtime",
+ "solana-sdk-ids",
+ "solana-zk-token-sdk",
+]
+
+[[package]]
+name = "solana-zk-token-sdk"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75b31849ca786c2da9c4d1a7292b33d5f8e697626b9eb5a53adf759a8409f6e"
+dependencies = [
+ "aes-gcm-siv",
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek 4.1.3",
+ "itertools 0.12.1",
+ "merlin",
+ "num-derive",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha3",
+ "solana-curve25519",
+ "solana-derivation-path",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "subtle",
+ "thiserror 2.0.12",
+ "zeroize",
 ]
 
 [[package]]
@@ -4593,6 +5092,16 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unreachable"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -18,6 +18,7 @@ bytemuck = { version = "1.23.0", features = ["derive"] }
 solana-sdk = "2.2.1"
 mollusk-svm = "0.4.0"
 mollusk-svm-bencher = "0.4.0"
+litesvm = "0.7.1"
 
 
 [features]

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -27,13 +27,20 @@ fn process_instruction(
         MyProgramInstruction::InitializeState => {
             msg!("Ix:0");
             instruction::process_initialize_state_v1(accounts, instruction_data)?;
-            instruction::process_initialize_state_v2(accounts,instruction_data)?;
             Ok(())
-
+        }
+        MyProgramInstruction::InitializeStateV2 => {
+            msg!("Ix:1");
+            instruction::process_initialize_state_v2(accounts, instruction_data)?;
+            Ok(())
         }
         MyProgramInstruction::UpdateState => {
-            msg!("Ix:1");
+            msg!("Ix:2");
             instruction::process_update_state_v1(accounts, instruction_data)?;
+            Ok(())
+        }
+        MyProgramInstruction::UpdateStateV2 => {
+            msg!("Ix:3");
             instruction::process_update_state_v2(accounts, instruction_data)?;
             Ok(())
         }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -2,13 +2,13 @@ use pinocchio::program_error::ProgramError;
 
 #[derive(Clone, PartialEq, shank::ShankType)]
 pub enum MyProgramError {
-    // overflow error
+    /// overflow error
     WriteOverflow,
-    // invalid instruction data
+    /// invalid instruction data
     InvalidInstructionData,
-    // pda mismatch
+    /// pda mismatch
     PdaMismatch,
-    // Invalid Owner
+    /// Invalid Owner
     InvalidOwner,
 }
 

--- a/program/src/instruction/initialize_mystate.rs
+++ b/program/src/instruction/initialize_mystate.rs
@@ -69,10 +69,12 @@ pub fn process_initialize_state_v1(accounts: &[AccountInfo], data: &[u8]) -> Pro
     if derived_my_state_pda.ne(state_acc.key()) {
         return Err(ProgramError::InvalidAccountOwner);
     }
+
     // log!("ix data owner: {}", &ix_data.owner);
     // log!("payer: {}", payer_acc.key());
     let bump_binding = [bump];
     //Signer Seeds
+    //  &[&[&[u8]]]
     let signer_seeds = [
         Seed::from(MyStateV1::SEED.as_bytes()),
         Seed::from(&ix_data.owner),

--- a/program/src/instruction/mod.rs
+++ b/program/src/instruction/mod.rs
@@ -9,7 +9,9 @@ pub use update_mystate::*;
 #[repr(u8)]
 pub enum MyProgramInstruction {
     InitializeState,
+    InitializeStateV2,
     UpdateState,
+    UpdateStateV2,
 }
 
 impl TryFrom<&u8> for MyProgramInstruction {
@@ -18,7 +20,9 @@ impl TryFrom<&u8> for MyProgramInstruction {
     fn try_from(value: &u8) -> Result<Self, Self::Error> {
         match *value {
             0 => Ok(MyProgramInstruction::InitializeState),
-            1 => Ok(MyProgramInstruction::UpdateState),
+            1 => Ok(MyProgramInstruction::InitializeStateV2),
+            2 => Ok(MyProgramInstruction::UpdateState),
+            3 => Ok(MyProgramInstruction::UpdateStateV2),
             _ => Err(ProgramError::InvalidInstructionData),
         }
     }

--- a/program/src/instruction/update_mystate.rs
+++ b/program/src/instruction/update_mystate.rs
@@ -1,6 +1,3 @@
-use bytemuck::{Pod, Zeroable};
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
 use crate::{
     error::MyProgramError,
     state::{
@@ -9,6 +6,9 @@ use crate::{
         Initialized, MyStateV1, MyStateV2,
     },
 };
+use bytemuck::{Pod, Zeroable};
+use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
+use pinocchio_log::log;
 
 // V1 instruction data (custom serialization)
 #[repr(C)]
@@ -43,6 +43,7 @@ pub fn process_update_state_v1(accounts: &[AccountInfo], data: &[u8]) -> Program
     }
 
     let my_state = unsafe { try_from_account_info_mut::<MyStateV1>(state_acc)? };
+    log!("my state: {}", &my_state.owner);
 
     // CHECK if my_state is initialized
     if !my_state.is_initialized() {

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -10,4 +10,4 @@ pub mod error;
 pub mod instruction;
 pub mod state;
 
-pinocchio_pubkey::declare_id!("ENrRns55VechXJiq4bMbdx7idzQh7tvaEJoYeWxRNe7Y");
+pinocchio_pubkey::declare_id!("3F5q36zsGX3Lcd8FQb7vTYmphvxHY8TFdBJVZzzepz31");

--- a/program/src/state/my_state.rs
+++ b/program/src/state/my_state.rs
@@ -3,12 +3,12 @@ use pinocchio::{
     account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
 };
 
-use bytemuck::{Pod,Zeroable};
+use bytemuck::{Pod, Zeroable};
 
 use crate::{
     error::MyProgramError,
     instruction::{InitializeMyStateV1IxData, UpdateMyStateV1IxData},
-    instruction::{InitializeMyStateV2IxData,UpdateMyStateV2IxData},
+    instruction::{InitializeMyStateV2IxData, UpdateMyStateV2IxData},
     state::try_from_account_info_mut,
 };
 
@@ -64,7 +64,7 @@ impl Initialized for MyStateV2 {
 }
 
 impl MyStateV1 {
-    pub const SEED: &'static str = "mystate";
+    pub const SEED: &'static str = "mystatev2";
 
     pub fn validate_pda(bump: u8, pda: &Pubkey, owner: &Pubkey) -> Result<(), ProgramError> {
         let seeds = &[Self::SEED.as_bytes(), owner];
@@ -75,7 +75,7 @@ impl MyStateV1 {
         Ok(())
     }
 
-    pub fn initialize( 
+    pub fn initialize(
         my_stata_acc: &AccountInfo,
         ix_data: &InitializeMyStateV1IxData,
         bump: u8,
@@ -103,10 +103,8 @@ impl MyStateV1 {
     }
 }
 
-
-
 impl MyStateV2 {
-    pub const SEED: &'static str = "mystatev2";
+    pub const SEED: &'static str = "mystate";
 
     //How to work without involving Enum (v1)
     pub fn get_state(&self) -> State {
@@ -114,15 +112,15 @@ impl MyStateV2 {
             0 => State::Uninitialized,
             1 => State::Initialized,
             2 => State::Updated,
-            _ => State::Uninitialized // for fallback
+            _ => State::Uninitialized, // for fallback
         }
     }
 
-    pub fn set_state(&mut self,state: State) {
+    pub fn set_state(&mut self, state: State) {
         self.state = state as u8;
     }
 
-   pub fn validate_pda(bump: u8, pda: &Pubkey, owner: &Pubkey) -> Result<(), ProgramError> {
+    pub fn validate_pda(bump: u8, pda: &Pubkey, owner: &Pubkey) -> Result<(), ProgramError> {
         let seeds = &[Self::SEED.as_bytes(), owner];
         let derived = pinocchio_pubkey::derive_address(seeds, bump, &crate::ID);
         if derived != *pda {
@@ -131,15 +129,14 @@ impl MyStateV2 {
         Ok(())
     }
 
-
-    pub fn initialize( 
+    pub fn initialize(
         my_stata_acc: &AccountInfo,
         ix_data: &InitializeMyStateV2IxData,
         bump: u8,
     ) -> ProgramResult {
-       //Using the Bytemuck for zero copy deserilization instead of unsafe block
-       let account_data = &mut my_stata_acc.try_borrow_mut_data()?;
-       let my_state = bytemuck::from_bytes_mut::<MyStateV2>(&mut account_data[..MyStateV2::LEN]);
+        //Using the Bytemuck for zero copy deserilization instead of unsafe block
+        let account_data = &mut my_stata_acc.try_borrow_mut_data()?;
+        let my_state = bytemuck::from_bytes_mut::<MyStateV2>(&mut account_data[..MyStateV2::LEN]);
 
         my_state.owner = ix_data.owner;
         my_state.set_state(State::Initialized);
@@ -160,6 +157,4 @@ impl MyStateV2 {
 
         Ok(())
     }
-
-
 }

--- a/program/src/state/my_state.rs
+++ b/program/src/state/my_state.rs
@@ -64,7 +64,7 @@ impl Initialized for MyStateV2 {
 }
 
 impl MyStateV1 {
-    pub const SEED: &'static str = "mystatev2";
+    pub const SEED: &'static str = "mystate";
 
     pub fn validate_pda(bump: u8, pda: &Pubkey, owner: &Pubkey) -> Result<(), ProgramError> {
         let seeds = &[Self::SEED.as_bytes(), owner];
@@ -104,7 +104,7 @@ impl MyStateV1 {
 }
 
 impl MyStateV2 {
-    pub const SEED: &'static str = "mystate";
+    pub const SEED: &'static str = "mystatev2";
 
     //How to work without involving Enum (v1)
     pub fn get_state(&self) -> State {

--- a/program/tests/unit_tests.rs
+++ b/program/tests/unit_tests.rs
@@ -9,8 +9,8 @@ extern crate alloc;
 use alloc::vec;
 
 use solana_pinocchio_starter::instruction::{InitializeMyStateV1IxData, UpdateMyStateV1IxData};
-use solana_pinocchio_starter::instruction::{InitializeMyStateV2IxData,UpdateMyStateV2IxData};
-use solana_pinocchio_starter::state::{to_bytes, DataLen, MyStateV1,MyStateV2};
+use solana_pinocchio_starter::instruction::{InitializeMyStateV2IxData, UpdateMyStateV2IxData};
+use solana_pinocchio_starter::state::{to_bytes, DataLen, MyStateV1, MyStateV2, State};
 use solana_pinocchio_starter::ID;
 use solana_sdk::rent::Rent;
 use solana_sdk::sysvar::Sysvar;
@@ -41,51 +41,86 @@ fn test_initialize_mystate() {
     let (system_program, system_account) = program::keyed_account_for_system_program();
 
     // Create the PDA
-    let (mystate_pda, _bump) =
+    let (mystate_pda_v2, _bump) =
         Pubkey::find_program_address(&[MyStateV2::SEED.as_bytes(), &PAYER.to_bytes()], &PROGRAM);
+
+    let (mystate_pda_v1, _bump) =
+        Pubkey::find_program_address(&[MyStateV1::SEED.as_bytes(), &PAYER.to_bytes()], &PROGRAM);
 
     //Initialize the accounts
     let payer_account = Account::new(1 * LAMPORTS_PER_SOL, 0, &system_program);
-    let mystate_account = Account::new(0, 0, &system_program);
+    let mystate_account_v1 = Account::new(0, 0, &system_program);
+    let mystate_account_v2 = Account::new(0, 0, &system_program);
     let min_balance = mollusk.sysvars.rent.minimum_balance(Rent::size_of());
     let mut rent_account = Account::new(min_balance, Rent::size_of(), &RENT);
     rent_account.data = get_rent_data();
 
     //Push the accounts in to the instruction_accounts vec!
-    let ix_accounts = vec![
+    let ix_accounts_v2 = vec![
         AccountMeta::new(PAYER, true),
-        AccountMeta::new(mystate_pda, false),
+        AccountMeta::new(mystate_pda_v2, false),
+        AccountMeta::new_readonly(RENT, false),
+        AccountMeta::new_readonly(system_program, false),
+    ];
+
+    let ix_accounts_v1 = vec![
+        AccountMeta::new(PAYER, true),
+        AccountMeta::new(mystate_pda_v1, false),
         AccountMeta::new_readonly(RENT, false),
         AccountMeta::new_readonly(system_program, false),
     ];
 
     // Create the instruction data
-    let ix_data = InitializeMyStateV2IxData {
+
+    let ix_data_v1 = InitializeMyStateV1IxData {
+        owner: *PAYER.as_array(),
+        data: [1; 32],
+    };
+    let ix_data_v2 = InitializeMyStateV2IxData {
         owner: *PAYER.as_array(),
         data: [1; 32],
     };
 
-    // Ix discriminator = 0
-    let mut ser_ix_data = vec![0];
+    // Ix discriminator = 0 and 1 for both init v1 and v2
+    let mut ser_ix_data_v1 = vec![0];
+    let mut ser_ix_data_v2 = vec![1];
 
     // Serialize the instruction data
-    ser_ix_data.extend_from_slice(unsafe { to_bytes(&ix_data) });
+    ser_ix_data_v1.extend_from_slice(unsafe { to_bytes(&ix_data_v1) });
+    ser_ix_data_v2.extend_from_slice(unsafe { to_bytes(&ix_data_v2) });
 
     // Create instruction
-    let instruction = Instruction::new_with_bytes(PROGRAM, &ser_ix_data, ix_accounts);
+    let instruction_v1 = Instruction::new_with_bytes(PROGRAM, &ser_ix_data_v1, ix_accounts_v1);
+    let instruction_v2 = Instruction::new_with_bytes(PROGRAM, &ser_ix_data_v2, ix_accounts_v2);
 
     // Create tx_accounts vec
-    let tx_accounts = &vec![
+
+    let tx_accounts_v1 = &vec![
         (PAYER, payer_account.clone()),
-        (mystate_pda, mystate_account.clone()),
+        (mystate_pda_v1, mystate_account_v1.clone()),
+        (RENT, rent_account.clone()),
+        (system_program, system_account.clone()),
+    ];
+    let tx_accounts_v2 = &vec![
+        (PAYER, payer_account.clone()),
+        (mystate_pda_v2, mystate_account_v2.clone()),
         (RENT, rent_account.clone()),
         (system_program, system_account.clone()),
     ];
 
-    let init_res =
-        mollusk.process_and_validate_instruction(&instruction, tx_accounts, &[Check::success()]);
+    let init_res_v1 = mollusk.process_and_validate_instruction(
+        &instruction_v1,
+        tx_accounts_v1,
+        &[Check::success()],
+    );
+    let init_res_v2 = mollusk.process_and_validate_instruction(
+        &instruction_v2,
+        tx_accounts_v2,
+        &[Check::success()],
+    );
 
-    assert!(init_res.program_result == ProgramResult::Success);
+    assert!(init_res_v1.program_result == ProgramResult::Success);
+    assert!(init_res_v2.program_result == ProgramResult::Success);
 }
 
 #[test]
@@ -96,7 +131,9 @@ fn test_update_mystate() {
     let (system_program, _system_account) = program::keyed_account_for_system_program();
 
     // Create the PDA
-    let (mystate_pda, bump) =
+    let (mystate_pda_v1, bump_v1) =
+        Pubkey::find_program_address(&[MyStateV1::SEED.as_bytes(), &PAYER.to_bytes()], &PROGRAM);
+    let (mystate_pda_v2, bump_v2) =
         Pubkey::find_program_address(&[MyStateV2::SEED.as_bytes(), &PAYER.to_bytes()], &PROGRAM);
 
     //Initialize the accounts
@@ -104,45 +141,77 @@ fn test_update_mystate() {
 
     let rent = mollusk.sysvars.rent.minimum_balance(MyStateV2::LEN);
 
-    let mut mystate_account = Account::new(rent, MyStateV2::LEN, &ID.into());
+    let mut mystate_account_v1 = Account::new(rent, MyStateV1::LEN, &ID.into());
+    let mut mystate_account_v2 = Account::new(rent, MyStateV2::LEN, &ID.into());
 
-    let my_state = MyStateV2 {
+    let my_state_v1 = MyStateV1 {
+        is_initialized: 1,
+        owner: *PAYER.as_array(),
+        state: State::Initialized,
+        data: [1; 32],
+        update_count: 0,
+        bump: bump_v1,
+    };
+    let my_state_v2 = MyStateV2 {
         is_initialized: 1,
         owner: *PAYER.as_array(),
         state: 1,
         data: [1; 32],
         update_count: 0,
-        bump,
-        _padding: 1
+        bump: bump_v2,
+        _padding: 1,
     };
 
-    mystate_account.data = unsafe { to_bytes(&my_state).to_vec() };
+    mystate_account_v1.data = unsafe { to_bytes(&my_state_v1).to_vec() };
+    mystate_account_v2.data = unsafe { to_bytes(&my_state_v2).to_vec() };
 
     //Push the accounts in to the instruction_accounts vec!
-    let ix_accounts = vec![
+    let ix_accounts_v1 = vec![
         AccountMeta::new(PAYER, true),
-        AccountMeta::new(mystate_pda, false),
+        AccountMeta::new(mystate_pda_v1, false),
+    ];
+    let ix_accounts_v2 = vec![
+        AccountMeta::new(PAYER, true),
+        AccountMeta::new(mystate_pda_v2, false),
     ];
 
     // Create the instruction data
-    let ix_data = UpdateMyStateV2IxData { data: [1; 32] };
+    let ix_data_v1 = UpdateMyStateV1IxData { data: [1; 32] };
+    let ix_data_v2 = UpdateMyStateV2IxData { data: [1; 32] };
 
-    // Ix discriminator = 1
-    let mut ser_ix_data = vec![1];
+    // Ix discriminator = 2, 3 for update v2 and v3 respectively
+    let mut ser_ix_data_v1 = vec![2];
+    let mut ser_ix_data_v2 = vec![3];
 
     // Serialize the instruction data
-    ser_ix_data.extend_from_slice(unsafe { to_bytes(&ix_data) });
+    ser_ix_data_v1.extend_from_slice(unsafe { to_bytes(&ix_data_v1) });
+    ser_ix_data_v2.extend_from_slice(unsafe { to_bytes(&ix_data_v2) });
 
     // Create instruction
-    let instruction = Instruction::new_with_bytes(PROGRAM, &ser_ix_data, ix_accounts);
+    let instruction_v1 = Instruction::new_with_bytes(PROGRAM, &ser_ix_data_v1, ix_accounts_v1);
+    let instruction_v2 = Instruction::new_with_bytes(PROGRAM, &ser_ix_data_v2, ix_accounts_v2);
+
     // Create tx_accounts vec
-    let tx_accounts = &vec![
+    let tx_accounts_v1 = &vec![
         (PAYER, payer_account.clone()),
-        (mystate_pda, mystate_account.clone()),
+        (mystate_pda_v1, mystate_account_v1.clone()),
+    ];
+    let tx_accounts_v2 = &vec![
+        (PAYER, payer_account.clone()),
+        (mystate_pda_v2, mystate_account_v2.clone()),
     ];
 
-    let update_res =
-        mollusk.process_and_validate_instruction(&instruction, tx_accounts, &[Check::success()]);
+    let update_res_v1 = mollusk.process_and_validate_instruction(
+        &instruction_v1,
+        tx_accounts_v1,
+        &[Check::success()],
+    );
+    let update_res_v2 = mollusk.process_and_validate_instruction(
+        &instruction_v2,
+        tx_accounts_v2,
+        &[Check::success()],
+    );
 
-    assert!(update_res.program_result == ProgramResult::Success);
+    assert!(update_res_v1.program_result == ProgramResult::Success);
+    assert!(update_res_v2.program_result == ProgramResult::Success);
 }


### PR DESCRIPTION
```rs
#[inline(always)]
fn process_instruction(
    _program_id: &Pubkey,
    accounts: &[AccountInfo],
    instruction_data: &[u8],
) -> ProgramResult {
    let (ix_disc, instruction_data) = instruction_data
        .split_first()
        .ok_or(ProgramError::InvalidInstructionData)?;

    match MyProgramInstruction::try_from(ix_disc)? {
        MyProgramInstruction::InitializeState => {
            msg!("Ix:0");
            instruction::process_initialize_state_v1(accounts, instruction_data)?;
            Ok(())
        }
        MyProgramInstruction::InitializeStateV2 => {
            msg!("Ix:1");
            instruction::process_initialize_state_v2(accounts, instruction_data)?;
            Ok(())
        }
        MyProgramInstruction::UpdateState => {
            msg!("Ix:2");
            instruction::process_update_state_v1(accounts, instruction_data)?;
            Ok(())
        }
        MyProgramInstruction::UpdateStateV2 => {
            msg!("Ix:3");
            instruction::process_update_state_v2(accounts, instruction_data)?;
            Ok(())
        }
    }
}

```